### PR TITLE
Naming convention in pod designer

### DIFF
--- a/dm-extension-scenarios/whereUsedReport/whereUsedPlugin/whereUsedPlugin/webapp/whereUsedPlugin/builder/PropertyEditor.js
+++ b/dm-extension-scenarios/whereUsedReport/whereUsedPlugin/whereUsedPlugin/webapp/whereUsedPlugin/builder/PropertyEditor.js
@@ -19,22 +19,22 @@ sap.ui.define([
 		addPropertyEditorContent: function(oPropertyFormContainer){
 			var oData = this.getPropertyData();
 			
-			this.addSwitch(oPropertyFormContainer, "backButtonVisible", oData);
-			this.addSwitch(oPropertyFormContainer, "closeButtonVisible", oData);						
-			this.addInputField(oPropertyFormContainer, "title", oData);
-			this.addInputField(oPropertyFormContainer, "text", oData);
-			this.addInputField(oPropertyFormContainer, "whereUsedPPD", oData);
+			this.addSwitch(oPropertyFormContainer, "custom_backButtonVisible", oData);
+			this.addSwitch(oPropertyFormContainer, "custom_closeButtonVisible", oData);						
+			this.addInputField(oPropertyFormContainer, "custom_title", oData);
+			this.addInputField(oPropertyFormContainer, "custom_text", oData);
+			this.addInputField(oPropertyFormContainer, "custom_whereUsedPPD", oData);
             oFormContainer = oPropertyFormContainer;
 		},
 		
 		getDefaultPropertyData: function(){
 			return {
 				
-				"backButtonVisible": true,
-				"closeButtonVisible": true,
-                "title": "whereUsedPlugin",
-				"text": "whereUsedPlugin",
-                "whereUsedPPD": "whereUsedPlugin"
+				"custom_backButtonVisible": true,
+				"custom_closeButtonVisible": true,
+                "custom_title": "whereUsedPlugin",
+				"custom_text": "whereUsedPlugin",
+                "custom_whereUsedPPD": "whereUsedPlugin"
 			};
 		}
 

--- a/dm-extension-scenarios/whereUsedReport/whereUsedPlugin/whereUsedPlugin/webapp/whereUsedPlugin/controller/MainView.controller.js
+++ b/dm-extension-scenarios/whereUsedReport/whereUsedPlugin/whereUsedPlugin/webapp/whereUsedPlugin/controller/MainView.controller.js
@@ -30,9 +30,9 @@ sap.ui.define([
         */
         onBeforeRenderingPlugin: function () {
             // retrieve configuration parameters set in during POD configuration in the POD Designer and assign them to view elements or variables
-            this.getView().byId("panelPlugin").setHeaderText(this.getConfiguration().title);
-            this.getView().byId("textPlugin").setText(this.getConfiguration().text);
-            this.swhereUsedPPDKey = this.getConfiguration().whereUsedPPD;
+            this.getView().byId("panelPlugin").setHeaderText(this.getConfiguration().custom_title);
+            this.getView().byId("textPlugin").setText(this.getConfiguration().custom_text);
+            this.swhereUsedPPDKey = this.getConfiguration().custom_whereUsedPPD;
         },
 
 


### PR DESCRIPTION
The POD designer configuration keys should not conflict with standard when placed in different containers such as Plugin container, Icon Tab Bar, Action Button or so. 